### PR TITLE
Add Skip Tags 

### DIFF
--- a/JobManager/Jobs/GitHubUpdateJob.cs
+++ b/JobManager/Jobs/GitHubUpdateJob.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Octokit;
 
 using System.Net;
 using System.Threading.Tasks;
@@ -28,11 +29,20 @@ namespace ChancyBot.Jobs
             return split[3] + "/" + split[4];
         }
 
-        public override void OnRun()
+        public async override void OnRun()
         {
             try
             {
-                string xml = new WebClient().DownloadString(this.url);
+				var client = new GitHubClient(new ProductHeaderValue("Steam-Discord-Bot"));
+
+				var commits = await client.Repository.Commit.GetAll("Headline22", "Steam-Discord-Bot");
+
+				if (commits[0].Commit.Message.Contains("[skip notify]")) // don't notify, continue normal operation
+				{
+					return;
+				}
+
+				string xml = new WebClient().DownloadString(this.url);
                 XDocument doc = XDocument.Parse(xml);
                 XNamespace ns = "http://www.w3.org/2005/Atom/";
 

--- a/JobManager/Jobs/SelfUpdateListener.cs
+++ b/JobManager/Jobs/SelfUpdateListener.cs
@@ -50,7 +50,7 @@ namespace ChancyBot.Jobs
                     {
                         int pid = Process.GetCurrentProcess().Id;
 
-                        var client = new GitHubClient(new ProductHeaderValue("my-cool-app"));
+                        var client = new GitHubClient(new ProductHeaderValue("Steam-Discord-Bot"));
                         var releases = await client.Repository.Release.GetAll("Headline22", "Steam-Discord-Bot");
 
                         string url = "https://github.com/Headline22/Steam-Discord-Bot/releases/download/<name>/steam-discord-bot.zip";

--- a/JobManager/Jobs/SelfUpdateListener.cs
+++ b/JobManager/Jobs/SelfUpdateListener.cs
@@ -50,7 +50,16 @@ namespace ChancyBot.Jobs
                     {
                         int pid = Process.GetCurrentProcess().Id;
 
-                        var client = new GitHubClient(new ProductHeaderValue("Steam-Discord-Bot"));
+						var client = new GitHubClient(new ProductHeaderValue("Steam-Discord-Bot"));
+
+						var commits = await client.Repository.Commit.GetAll("Headline22", "Steam-Discord-Bot");
+						
+                        if (commits[0].Commit.Message.Contains("[skip update]")) // don't force updates, continue normal operation
+                        {
+                            commit = current;
+                            return;
+                        }
+                        
                         var releases = await client.Repository.Release.GetAll("Headline22", "Steam-Discord-Bot");
 
                         string url = "https://github.com/Headline22/Steam-Discord-Bot/releases/download/<name>/steam-discord-bot.zip";


### PR DESCRIPTION
`[skip update]` will now block the bot from updating to the commit. Useful for readme updates and stuff like that.

`[skip notify]` will stop the bot from notifying the discord for useless updates.