### PR TITLE
Add (Google) Search Command

### DIFF
--- a/Commands/Search.cs
+++ b/Commands/Search.cs
@@ -1,0 +1,198 @@
+﻿
+//System
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+//Discord 
+using Discord.Commands;
+
+//Google 
+using static Google.Apis.Customsearch.v1.CseResource;
+using static Google.Apis.Customsearch.v1.CseResource.ListRequest;
+using Google.Apis.Services;
+using Google.Apis.Customsearch.v1;
+
+namespace SteamDiscordBot.Commands
+{
+    public class Search : ModuleBase
+    {
+        public static readonly int DEFAULT_SEARCH_NUMBER = 1;
+        public static readonly string[] FLAGS = new string[] { "-safesearch", "-num"};
+
+        public static CustomsearchService service = new CustomsearchService(new BaseClientService.Initializer { ApiKey = API_KEY });
+
+        //bitfield
+        public enum GOOGLEFLAGS : uint
+        {
+            SAFESEARCH = (1<<0),
+            NUM = (1<<1)
+        }
+
+        SafeEnum
+
+        [Command("search"), Summary("Peforms google search and returns result(s)")]
+        public async Task Say(params string[] args)
+        {
+            GOOGLEFLAGS flags = 0;
+            // safe search
+
+            flags |= GOOGLEFLAGS.SAFESEARCH;
+            if ((flags & GOOGLEFLAGS.SAFESEARCH) == GOOGLEFLAGS.SAFESEARCH)
+            {
+            }
+
+            FindFlags(args);
+
+            args = RemoveArguementFlags(args, '-');
+            if (args.Length == 0) { return; }
+            string input = FormatInput(args);
+
+            try
+            {
+                string output = "";
+                ListRequest listRequest = service.Cse.List(input);
+                listRequest.Cx = SEARCH_ENGINE_ID;
+                listRequest.Safe = DEFAULT_SAFETY_LEVEL;
+
+                if (Current_Search_Flags.Any()) { HandleSearchFlags(listRequest); }
+                var search = listRequest.Execute();
+
+                for (int i = 0; i < Current_Search_Result_Number; i++)
+                {
+                    output += search.Items?[i].Link.ToString() + "\n";
+                }
+
+                ResetForNextQuery();
+                if (output == "\n")
+                    throw new ArgumentException();
+                await Context.Channel.SendMessageAsync(output);
+            }
+
+            catch (ArgumentException)
+            {
+                await Context.Channel.SendMessageAsync("No search results found");
+            }
+            catch (Exception e)
+            {
+                await Program.Instance.Log(new Discord.LogMessage(Discord.LogSeverity.Verbose, "SearchCMD", e.Message));
+                await Context.Channel.SendMessageAsync(e.Message);
+            }
+        }
+
+        public static void FindFlags(string[] args)
+        {
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (ValidFlagFound(args[i]))
+                {
+                    Current_Search_Flags.Add(args[i]); //Adds flag to List to handle later
+                }
+            }
+        }
+
+        public static string FormatInput(string[] args)
+        {
+            string input = "";
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                input += args[i] + " ";
+            }
+            input += args[args.Length - 1];
+            return input;
+        }
+
+        public static SafeEnum GetSearchSafetyLevel(string input)
+        {
+            input = input.ToLower();
+            if (input == "high")
+            {
+                return ListRequest.SafeEnum.High; // Search level safety: high
+            }
+            else if (input == "medium")
+            {
+                return ListRequest.SafeEnum.Medium; // Search level safety: medium
+            }
+            else if (input == "off")
+            {
+                return ListRequest.SafeEnum.Off; // Search level safety: off
+            }
+            else
+            {
+                return DEFAULT_SAFETY_LEVEL; //Invalid input given, use default value
+            }
+        }
+
+        public static void HandleSearchFlags(ListRequest listrequest)
+        {
+            string flag = "";
+            string value = "";
+
+            foreach (string item in Current_Search_Flags)
+            {
+                flag = item.Split('_')[0];
+                value = item.Split('_')[1];
+
+                switch (flag)
+                {
+                    case "-safesearch":
+                        listrequest.Safe = GetSearchSafetyLevel(value);
+                        break;
+
+                    case "-ss":
+                        listrequest.Safe = GetSearchSafetyLevel(value);
+                        break;
+
+                    case "-num":
+                        int number = -1;
+                        if (int.TryParse(value, out number))
+                        {
+                            if(number <= SEARCH_MAX_COUNT && number >= 1)
+                            {
+                                Current_Search_Result_Number = number;
+                            }
+                        }
+                        break;
+
+                    default:
+                        break;
+
+                }
+            }
+        }
+
+        public static bool ValidFlagFound(string arg)
+        {
+            int index = arg.IndexOf('-');
+            if (index == -1) { return false; }
+            index = arg.IndexOf('_');
+            if ((index + 1) > arg.Length) { return false; }
+
+            return true;
+        }
+
+        public static string[] RemoveArguementFlags(string[] args, char flag)
+        {
+            string temp = "";
+            string output = "";
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                temp = args[i];
+                if (temp[0] != flag)
+                {
+                    output += temp + " ";
+                }
+            }
+
+            return output.Split(' '); //search halo
+        }
+        public static void ResetForNextQuery()
+        {
+            Current_Search_Flags.Clear();
+            Current_Search_Result_Number = DEFAULT_SEARCH_NUMBER;
+        }
+    }
+
+}

--- a/Settings.json
+++ b/Settings.json
@@ -37,5 +37,10 @@
    
    "GitHubUpdateUsername": "Headline",
    "GitHubUpdateRepository": "Steam-Discord-Bot",
-   "GitHubUpdateReleaseFilename": "steam-discord-bot.zip"
+   "GitHubUpdateReleaseFilename": "steam-discord-bot.zip",
+
+   "GoogleApiKey" : "",
+   "GoogleSearchEngineID" : "",
+   "GoogleSafeSearchActive" : false,
+   "GoogleMaxSearchNumber" : 10
 }

--- a/Steam-Discord-Bot.csproj
+++ b/Steam-Discord-Bot.csproj
@@ -53,6 +53,18 @@
     <Reference Include="Discord.Net.WebSocket, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Discord.Net.WebSocket.1.0.2\lib\net45\Discord.Net.WebSocket.dll</HintPath>
     </Reference>
+    <Reference Include="Google.Apis, Version=1.35.2.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.35.2\lib\net45\Google.Apis.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Core, Version=1.35.2.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Core.1.35.2\lib\net45\Google.Apis.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Customsearch.v1, Version=1.35.2.1322, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Customsearch.v1.1.35.2.1322\lib\net45\Google.Apis.Customsearch.v1.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.35.2.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.35.2\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    </Reference>
     <Reference Include="JsonConfig, Version=1.0.6631.20962, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>deps\JsonConfig.dll</HintPath>
@@ -129,6 +141,7 @@
     <Compile Include="Commands\Ping.cs" />
     <Compile Include="Commands\Pony.cs" />
     <Compile Include="Commands\Repeat.cs" />
+    <Compile Include="Commands\Search.cs" />
     <Compile Include="Commands\SetGame.cs" />
     <Compile Include="Commands\Substitute.cs" />
     <Compile Include="Commands\Update.cs" />

--- a/packages.config
+++ b/packages.config
@@ -8,6 +8,9 @@
   <package id="Discord.Net.Rpc" version="1.0.2" targetFramework="net452" />
   <package id="Discord.Net.Webhook" version="1.0.2" targetFramework="net452" />
   <package id="Discord.Net.WebSocket" version="1.0.2" targetFramework="net452" />
+  <package id="Google.Apis" version="1.35.2" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.35.2" targetFramework="net452" />
+  <package id="Google.Apis.Customsearch.v1" version="1.35.2.1322" targetFramework="net452" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Markov" version="2.0.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.1.1" targetFramework="net452" />


### PR DESCRIPTION
Bot command that streamlines searching things on the web. Allows the user to perform a google search and returns the link(s) found. Although this adds another dependency, I feel this is another useful command for the user.

**Example Usage**
![snip1](https://user-images.githubusercontent.com/26758608/46568023-454bbe00-c8f3-11e8-9177-0c0d7e77ede9.PNG)

You can also attach flags to the command allowing to turn on safesearch and increase the amount of results returned. Flags include: **-safesearch_active**, **-safesearch_off**, **-num_** *value* (value being an integer)

![snip2](https://user-images.githubusercontent.com/26758608/46568024-454bbe00-c8f3-11e8-9766-93e6e20c02bb.PNG)


